### PR TITLE
Added CUDA version detect

### DIFF
--- a/src/CuTropicalGEMM.jl
+++ b/src/CuTropicalGEMM.jl
@@ -3,6 +3,12 @@ module CuTropicalGEMM
 using CUDA, TropicalNumbers, LinearAlgebra, TropicalGemmC_jll 
 export matmul!
 
+function __init__()
+    @assert CUDA.driver_version() >= v"11.4" "Error: CUDA.driver_version < v11.4"
+    @assert CUDA.driver_version() <= v"12.1" "Error: CUDA.driver_version > v12.1"
+    return nothing
+end
+
 const Symbol_FP32 = (:FP32, "FP32")
 const Symbol_FP64 = (:FP64, "FP64")
 const Symbol_INT32 = (:INT32, "INT32")

--- a/src/CuTropicalGEMM.jl
+++ b/src/CuTropicalGEMM.jl
@@ -5,7 +5,7 @@ export matmul!
 
 function __init__()
     @assert CUDA.driver_version() >= v"11.4" "Error: CUDA.driver_version < v11.4"
-    @assert CUDA.driver_version() <= v"12.1" "Error: CUDA.driver_version > v12.1"
+    @assert CUDA.driver_version() <= v"12.2" "Error: CUDA.driver_version > v12.2"
     return nothing
 end
 


### PR DESCRIPTION
I added a CUDA version detect in
```
function __init__()
    @assert CUDA.driver_version() >= v"11.4" "Error: CUDA.driver_version < v11.4"
    @assert CUDA.driver_version() <= v"12.1" "Error: CUDA.driver_version > v12.1"
    return nothing
end
```
to make sure the driver version satisfies `v"11.4" <= CUDA.driver_version() <= v"12.1"`.

I updated https://github.com/JuliaPackaging/Yggdrasil/pull/7541 so that the binary package will support the CUDA versions above, but I did not successfully support CUDA v12.2, because one of the deps we are using now only support v12.1 (https://github.com/JuliaBinaryWrappers/CUDA_full_jll.jl).