### PR TITLE
Add device detector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CuTropicalGEMM"
 uuid = "c2b282c3-c9c2-431d-80f7-a1a0561ebe55"
 authors = ["Xuanzhao Gao <gaoxuanzhao@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -11,7 +11,7 @@ TropicalNumbers = "b3a74e9c-7526-4576-a4eb-79c0d4c32334"
 
 [compat]
 CUDA = "5"
-TropicalGemmC_jll = "0.1"
+TropicalGemmC_jll = "0.1.1"
 TropicalNumbers = "0.6.2"
 julia = "1"
 

--- a/src/CuTropicalGEMM.jl
+++ b/src/CuTropicalGEMM.jl
@@ -4,8 +4,15 @@ using CUDA, TropicalNumbers, LinearAlgebra, TropicalGemmC_jll
 export matmul!
 
 function __init__()
-    @assert CUDA.driver_version() >= v"11.4" "Error: CUDA.driver_version < v11.4"
-    @assert CUDA.driver_version() <= v"12.2" "Error: CUDA.driver_version > v12.2"
+    if CUDA.functional() == true
+        if CUDA.driver_version() < v"11.4"
+            @warn "CUDA.driver_version < v11.4! CuTropicalGEMM may not be available."
+        elseif CUDA.driver_version() > v"12.2"
+            @warn "CUDA.driver_version > v12.2! CuTropicalGEMM may not be available."
+        end
+    elseif CUDA.functional() == false
+        @warn "CUDA Driver not found! CuTropicalGEMM will not be available."
+    end
     return nothing
 end
 

--- a/src/tropical_gemms.jl
+++ b/src/tropical_gemms.jl
@@ -15,9 +15,9 @@ for (TA, tA) in [(:CuVecOrMat, 'N'), (:CTranspose, 'T')]
     for (TB, tB) in [(:CuVecOrMat, 'N'), (:CTranspose, 'T')]
         for (TT, CT, funcname, lib) in [
             (:Float32, :Cfloat, :FLOAT_plusmul, :lib_PlusMul_FP32), (:Float64, :Cdouble, :DOUBLE_plusmul, :lib_PlusMul_FP64), (:Int32, :Cint, :INT_plusmul, :lib_PlusMul_INT32), (:Int64, :Clong, :LONG_plusmul, :lib_PlusMul_INT64), 
-            (:TropicalAndOr, :Bool, :BOOL_andor, :TropicalAndOr_Bool), 
-            (:TropicalMaxPlusF32, :Cfloat, :FLOAT_maxplus, :TropicalMaxPlus_FP32), (:TropicalMaxPlusF64, :Cdouble, :DOUBLE_maxplus, :TropicalMaxPlus_FP64), 
-            (:TropicalMinPlusF32, :Cfloat, :FLOAT_minplus, :TropicalMinPlus_FP32), (:TropicalMinPlusF64, :Cdouble, :DOUBLE_minplus, :TropicalMinPlus_FP64), 
+            (:TropicalAndOr, :Bool, :BOOL_andor, :lib_TropicalAndOr_Bool), 
+            (:TropicalMaxPlusF32, :Cfloat, :FLOAT_maxplus, :lib_TropicalMaxPlus_FP32), (:TropicalMaxPlusF64, :Cdouble, :DOUBLE_maxplus, :lib_TropicalMaxPlus_FP64), 
+            (:TropicalMinPlusF32, :Cfloat, :FLOAT_minplus, :lib_TropicalMinPlus_FP32), (:TropicalMinPlusF64, :Cdouble, :DOUBLE_minplus, :lib_TropicalMinPlus_FP64), 
             (:TropicalMaxMulF32, :Cfloat, :FLOAT_maxmul, :lib_TropicalMaxMul_FP32), (:TropicalMaxMulF64, :Cdouble, :DOUBLE_maxmul, :lib_TropicalMaxMul_FP64), (:TropicalMaxMulI32, :Cint, :INT_maxmul, :lib_TropicalMaxMul_INT32), (:TropicalMaxMulI64, :Clong, :LONG_maxmul, :lib_TropicalMaxMul_INT64)
             ]
             @eval function matmul!(C::CuVecOrMat{T}, A::$TA{T}, B::$TB{T}, α::T, β::T) where {T<:$TT}


### PR DESCRIPTION
I found that the Julia register server do not have cuda device, while the init function we used need to call `CUDA.device_version()`. This can lead to error.
I added a device detector using `CUDA.functional()` to check is there any CUDA device to use, if no, it will output a `warning` message.